### PR TITLE
Add resurrect support for multiple sockets

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -105,7 +105,7 @@ resurrect_dir() {
 		echo "$_RESURRECT_DIR"
 	fi
 }
-_RESURRECT_DIR="$(resurrect_dir)"
+_RESURRECT_DIR="$(resurrect_dir)/$(basename "${TMUX%%,*}")"
 
 resurrect_file_path() {
 	if [ -z "$_RESURRECT_FILE_PATH" ]; then


### PR DESCRIPTION
## Summary

This change appends `socket_name` from `tmux` as parent directory when saving sessions.
With this, we can save sessions with different `socket` names.
Previously, `tmux-resurrect` saved everything in the same directory.

## Example
Run separate sessions with custom `socket` name:
```
tmux -L $socket
```
Now, when `tmux-resurrect` saves `tmux` state, it will be save to `${resurrect_dir}/${socket}`.